### PR TITLE
Fix m5cores3_display componant to match ESPHome display componant methods

### DIFF
--- a/components/m5cores3_display/m5cores3_display.cpp
+++ b/components/m5cores3_display/m5cores3_display.cpp
@@ -39,8 +39,8 @@ void M5CoreS3Display::setup() {
 
 float M5CoreS3Display::get_setup_priority() const { return setup_priority::HARDWARE; }
 void M5CoreS3Display::dump_config() {}
-int M5CoreS3Display::get_width() { return M5.Display.width(); }
-int M5CoreS3Display::get_height() { return M5.Display.height(); }
+int M5CoreS3Display::get_width_internal() { return M5.Display.width(); }
+int M5CoreS3Display::get_height_internal() { return M5.Display.height(); }
 
 
 void M5CoreS3Display::draw_pixel_at(int x, int y, Color color) {

--- a/components/m5cores3_display/m5cores3_display.h
+++ b/components/m5cores3_display/m5cores3_display.h
@@ -9,8 +9,8 @@ class M5CoreS3Display : public display::Display {
   void setup() override;
   float get_setup_priority() const override;
   void dump_config() override;
-  int get_width() override;
-  int get_height() override;
+  int get_width_internal() override;
+  int get_height_internal() override;
 
   display::DisplayType get_display_type() override { return display::DisplayType::DISPLAY_TYPE_COLOR; }
   void fill(Color color) override;


### PR DESCRIPTION
There has been a change in in [ESPHome source code](https://github.com/esphome/esphome/tree/dev/esphome/components/display) in the name of some methods in the [ili9xxx component](https://esphome.io/components/display/ili9xxx.html).

This PR fixes #11 issue: invalid new-expression of abstract class type `'esphome::m5cores3_display::M5CoreS3Display'`.

This ensures that `m5cores3_display` componant matches ESPHome display componant methods.