### PR TITLE
fix: restructure microphone API to match ESPHome architecture

### DIFF
--- a/components/m5cores3_audio/microphone/i2s_audio_microphone.h
+++ b/components/m5cores3_audio/microphone/i2s_audio_microphone.h
@@ -22,7 +22,6 @@ class I2SAudioMicrophone : public I2SAudioIn, public microphone::Microphone, pub
   void set_din_pin(int8_t pin) { this->din_pin_ = pin; }
   void set_pdm(bool pdm) { this->pdm_ = pdm; }
 
-  size_t read(int16_t *buf, size_t len) override;
 
 #if SOC_I2S_SUPPORTS_ADC
   void set_adc_channel(adc1_channel_t channel) {
@@ -37,7 +36,7 @@ class I2SAudioMicrophone : public I2SAudioIn, public microphone::Microphone, pub
  protected:
   void start_();
   void stop_();
-  void read_();
+  size_t read_(uint8_t *buf, size_t len, TickType_t ticks_to_wait);
 
   int8_t din_pin_{I2S_PIN_NO_CHANGE};
 #if SOC_I2S_SUPPORTS_ADC


### PR DESCRIPTION
- Remove incorrect read() override that doesn't exist in base class
- Replace with private read_() method matching native implementation signature
- Update loop() to directly handle uint8_t buffer and data callbacks
- Add proper int16_t to uint8_t conversion for M5Stack microphone data

This resolves compilation failures on the latest ESPHome versions due to changes in the underlying I2S microphone component.

Closes #27 